### PR TITLE
Checking in for inaugural test run

### DIFF
--- a/.github/workflows/dotnet-cd.yaml
+++ b/.github/workflows/dotnet-cd.yaml
@@ -1,0 +1,41 @@
+name: .NET Continuous Integration
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      update_version:
+        description: 'Update version (creates a new release)'
+        required: false
+        type: boolean
+        default: false
+      custom_tags:
+        description: 'Custom package tags (comma-separated)'
+        required: false
+        default: ''
+      custom_description:
+        description: 'Custom package description'
+        required: false
+        default: ''
+
+jobs:
+  build-and-test:
+    # Skip if push event with [skip cd] in commit message
+    if: "github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip cd]')"
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Run .NET CI Action
+        uses: jmsudar/dotnet-continuous-deployment@jms-integrate-test-repo
+        with: 
+          package-id: '${{ github.repository_owner }}.${{ github.event.repository.name }}'
+          author: ${{ github.repository_owner }}
+          repository-url: 'git@github.com:${{ github.repository }}.git'
+          package-tags: ${{ github.event.inputs.custom_tags || 'utility,test,automation' }} 
+          license: 'GPL-3.0-or-later'
+          update_version: ${{ github.event_name == 'push' && true || github.event.inputs.update_version }}
+

--- a/.github/workflows/dotnet-cd.yaml
+++ b/.github/workflows/dotnet-cd.yaml
@@ -21,7 +21,7 @@ on:
         default: ''
 
 jobs:
-  build-and-test:
+  publish:
     # Skip if push event with [skip cd] in commit message
     if: "github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip cd]')"
     permissions:

--- a/.github/workflows/dotnet-cd.yaml
+++ b/.github/workflows/dotnet-cd.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: Run .NET CI Action
         uses: jmsudar/dotnet-continuous-deployment@jms-integrate-test-repo
         with: 
+          nuget-api-key: ${{ secrets.NUGET_API_KEY }}
           package-id: '${{ github.repository_owner }}.${{ github.event.repository.name }}'
           author: ${{ github.repository_owner }}
           repository-url: 'git@github.com:${{ github.repository }}.git'

--- a/.github/workflows/dotnet-ci.yaml
+++ b/.github/workflows/dotnet-ci.yaml
@@ -1,0 +1,11 @@
+name: .NET Continuous Integration
+
+on:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run .NET CI Action
+        uses: jmsudar/dotnet-continuous-integration@jms-integrate-test-repo

--- a/.github/workflows/dotnet-ci.yaml
+++ b/.github/workflows/dotnet-ci.yaml
@@ -9,3 +9,5 @@ jobs:
     steps:
       - name: Run .NET CI Action
         uses: jmsudar/dotnet-continuous-integration@jms-integrate-test-repo
+        with:
+          nuget-api-key: ${{ secrets.NUGET_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,152 @@
+# Standard .NET and Visual Studio files/directories
+[Bb]in/
+[Oo]bj/
+[Ll]ogs/
+[Pp]ackages/
+[Tt]est[Rr]esults/
+.vs/
+
+# OS specific files
+# macOS
+.DS_Store
+# Windows
+Thumbs.db
+Desktop.ini
+# Linux
+.directory
+.*.sw?
+.bash_history
+# Temporary files
+*~
+
+# Generated files
+*.user
+*.userosscache
+*.suo
+*.userprefs
+*.pidb
+*.cache
+*.vsp
+*.vspscc
+*_i.c
+*_p.c
+*.ncb
+*.sln.docstates
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# NUNIT
+*.VisualState.xml
+TestResult.xml
+
+# BenchmarkDotNet Artifacts
+BenchmarkDotNet.Artifacts/
+
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# ASP.NET Scaffolding
+ScaffoldingReadMe.txt
+
+# Files built by Visual Studio
+*_i.h
+*_p.h
+*_i.cpp
+*_p.cpp
+*_h.h
+*_h.cpp
+*_i.cs
+*_p.cs
+*.dbmdl
+*.dbproj.schemaview
+*.jfm
+*.pfx
+*.publishsettings
+orleans.codegen.cs
+
+# Visual Studio code coverage results
+*.coverage
+*.coveragexml
+
+# DocProject is a documentation generator add-in
+DocProject/buildhelp/
+DocProject/Help/Html2
+DocProject/Help/html
+
+# Click-Once directory
+publish/
+
+# Publish Web Output
+*.[Pp]ublish.xml
+*.azurePubxml
+# Note: Comment the next line if you want to checkin your web deploy settings,
+# but database connection strings (with potential passwords) will be unencrypted
+*.pubxml
+*.publishproj
+
+# NuGet Packages Directory
+*.nupkg
+**/[Pp]ackages/*
+!**/[Pp]ackages/build/
+*.nuget.props
+*.nuget.targets
+
+# Microsoft Azure Build Output
+csx/
+*.build.csdef
+
+# Microsoft Azure Emulator
+ecf/
+rcf/
+
+# Windows Store app package directories and files
+AppPackages/
+BundleArtifacts/
+Package.StoreAssociation.xml
+_pkginfo.txt
+*.appx
+*.appxbundle
+*.appxupload
+
+# Visual Studio cache files
+*.[Cc]ache
+!*.[Cc]ache/
+
+# Others
+ClientBin/
+~$*
+*~
+*.dbmdl
+*.dbproj.schemaview
+*.jfm
+*.pfx
+*.publishsettings
+orleans.codegen.cs
+
+# Including strong name files can present a security risk
+*.snk
+
+# RIA/Silverlight projects
+Generated_Code/
+
+# Backup & report files from converting an old project file to a newer
+_UpgradeReport_Files/
+Backup*/
+UpgradeLog*.XML
+UpgradeLog*.htm
+ServiceFabricBackup/
+*.rptproj.bak
+
+# SQL Server files
+*.mdf
+*.ldf
+*.ndf
+
+# Business Intelligence projects
+*.rdl.data
+*.bim.layout
+*.bim_*.settings

--- a/DotNet.CICDTest.sln
+++ b/DotNet.CICDTest.sln
@@ -1,0 +1,36 @@
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNet.CICDTest", "src\DotNet.CICDTest\DotNet.CICDTest.csproj", "{28B5477C-756D-E358-2932-820FD336E592}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNet.CICDTest.Tests", "src\DotNet.CICDTest.Tests\DotNet.CICDTest.Tests.csproj", "{C27D7DF0-8FEB-480F-813F-59ADC65E8678}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{28B5477C-756D-E358-2932-820FD336E592}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{28B5477C-756D-E358-2932-820FD336E592}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{28B5477C-756D-E358-2932-820FD336E592}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{28B5477C-756D-E358-2932-820FD336E592}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C27D7DF0-8FEB-480F-813F-59ADC65E8678}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C27D7DF0-8FEB-480F-813F-59ADC65E8678}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C27D7DF0-8FEB-480F-813F-59ADC65E8678}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C27D7DF0-8FEB-480F-813F-59ADC65E8678}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{28B5477C-756D-E358-2932-820FD336E592} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{C27D7DF0-8FEB-480F-813F-59ADC65E8678} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D5C36BDE-CA15-4693-B4D2-9F8A222275CD}
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
 # DotNet.CICDTest
-Integration test for .NET CI and CD workflows.
+
+This repo exists to provide a testing ground for the following GitHub aciton workflows:
+
+- [dotnet-continuous-integration](https://github.com/jmsudar/dotnet-continuous-integration)
+- [dotnet-continuous-deployment](https://github.com/jmsudar/dotnet-continous-deployment)
+
+This library project is not meant to be a useful tool nor solve any problems through the library itself. Instead, it contains a very simple Hello, World! method along with a unit test. These methods are unlikely to change, as their simplicity and predictability make the purpose of this repo easier to test.
+
+Changes to either the .NET CI or CD actions up above will then be reflected with a version listed in the table below. 
+
+### `dotnet-continuous-integration`
+
+Updating the README and opening a PR will then kick off a run of `dotnet-continuous-integration`. This is a simple github action that performs the following steps:
+
+1. Checks out the repo.
+2. Installs .NET in whichever version you specify (at time of writing, default is .NET 6.0).
+3. Performs a `dotnet restore`.
+4. Builds the projects with the specified configuration (defaults to `Release`).
+5. Runs `dotnet test` at the specified verbosity (defaults to `normal`).
+
+These actions ensure that a .NET library that uses this CI action can build, and that all unit tests will succeed. Setting this action as a check on your repo's protected branches will then guarantee changes, and allow CD to proceed successfully after merge.
+
+#### Testing Failure
+
+To test the failure state and the formatting of the output, there are a couple of lines to uncomment for the purposes of testing success, failure, and formatting of both.
+
+Success and failure is marked in comments, either `successful test case` or `failure test case`.
+
+### `dotnet-continous-deployment`
+
+Merging the PR that tests `dotnet-continous-integration` will continue the process and create a NuGet package push and publish. The following steps take place:
+
+1. Rerun `dotnet-continuous-integration` to verify the code being published can build and passes all tests. This will also test that a repository variable, `NUGET_API_KEY` is present, which is required for the publish step.
+2. 
+
+## Testing versions
+
+The table below indicates what is being tested. New entries in this table correspond to improvements in either action. The columns are
+
+- `Date`: The date of the work being done
+- `dotnet-ci`: The branch being in `dotnet-ci`, if applicable
+- `dotnet-cd`: The branch being in `dotnet-cd`, if applicable
+- `Description`: A description of the work being done
+
+| Date | `dotnet-ci` | `dotnet-cd` | Description |
+| :-: | :-: | :-: | :- |
+| 7/20/2025 | jms-integrate-test-repo | jms-integrate-test-repo | Initial implementation of this test repo. Tests new formatting options within `dotnet-ci`, and tests end-to-end readiness of `dotnet-cd`.

--- a/src/DotNet.CICDTest.Tests/DotNet.CICDTest.Tests.cs
+++ b/src/DotNet.CICDTest.Tests/DotNet.CICDTest.Tests.cs
@@ -17,10 +17,10 @@ namespace DotNet.CICDTest.Tests
         public void TestGetGreeting()
         {
             // Arrange, successful test case
-            // string expected = "Hello, World!";
+            string expected = "Hello, World!";
 
             // Arrange, failure test case
-            string expected = "Hello, Universe!";
+            // string expected = "Hello, Universe!";
 
             // Act
             string actual = TestMethods.GetGreeting();

--- a/src/DotNet.CICDTest.Tests/DotNet.CICDTest.Tests.cs
+++ b/src/DotNet.CICDTest.Tests/DotNet.CICDTest.Tests.cs
@@ -1,0 +1,74 @@
+using jmsudar.DotNet.CICDTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DotNet.CICDTest.Tests
+{
+
+    /// <summary>
+    /// This class contains unit tests for the TestMethods class.
+    /// It is important to verify failure state for `dotnet-ci` so 
+    /// there are several values you can comment in or out below
+    /// in order to manipulate the tests to pass or fail.
+    /// </summary>
+    [TestClass]
+    public class TestMethodsTests
+    {
+        [TestMethod]
+        public void TestGetGreeting()
+        {
+            // Arrange, successful test case
+            string expected = "Hello, World!";
+
+            // Arrange, failure test case
+            // string expected = "Hello, Universe!";
+
+            // Act
+            string actual = TestMethods.GetGreeting();
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        /// <summary>
+        /// This test method verifies the Add method of the TestMethods class.
+        /// </summary>
+        [TestMethod]
+        public void TestAdd()
+        {
+            // Arrange, successful test case
+            int a = 5;
+            int b = 10;
+            int expected = 15;
+
+            // Arrange, failure test case
+            // int expected = 20;
+
+            // Act
+            int actual = TestMethods.Add(a, b);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+        
+        /// <summary>
+        /// This test method verifies the Concat method of the TestMethods class.
+        /// </summary>
+        [TestMethod]
+        public void TestConcat()
+        {
+            // Arrange, successful test case
+            string str1 = "Hello";
+            string str2 = "World";
+            string expected = "Hello World";
+
+            // Arrange, failure test case
+            // string expected = "Hello Universe";
+
+            // Act
+            string actual = TestMethods.Concat(str1, str2);
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/src/DotNet.CICDTest.Tests/DotNet.CICDTest.Tests.cs
+++ b/src/DotNet.CICDTest.Tests/DotNet.CICDTest.Tests.cs
@@ -17,10 +17,10 @@ namespace DotNet.CICDTest.Tests
         public void TestGetGreeting()
         {
             // Arrange, successful test case
-            string expected = "Hello, World!";
+            // string expected = "Hello, World!";
 
             // Arrange, failure test case
-            // string expected = "Hello, Universe!";
+            string expected = "Hello, Universe!";
 
             // Act
             string actual = TestMethods.GetGreeting();

--- a/src/DotNet.CICDTest.Tests/DotNet.CICDTest.Tests.csproj
+++ b/src/DotNet.CICDTest.Tests/DotNet.CICDTest.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotNet.CICDTest\DotNet.CICDTest.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/DotNet.CICDTest/DotNet.CICDTest.cs
+++ b/src/DotNet.CICDTest/DotNet.CICDTest.cs
@@ -12,7 +12,7 @@
         public static string GetGreeting()
         {
             // To test presentation of warnings, uncomment the line below to set an unused variable
-            string unusedVariable = "This variable is not used anywhere";
+            // string unusedVariable = "This variable is not used anywhere";
 
             return "Hello, World!";
         }
@@ -26,7 +26,7 @@
         public static int Add(int a, int b)
         {
             // To test presentation of errors, comment out the line below so that a value is not returned
-            //return a + b;
+            return a + b;
         }
 
         /// <summary>

--- a/src/DotNet.CICDTest/DotNet.CICDTest.cs
+++ b/src/DotNet.CICDTest/DotNet.CICDTest.cs
@@ -12,7 +12,7 @@
         public static string GetGreeting()
         {
             // To test presentation of warnings, uncomment the line below to set an unused variable
-            // string unusedVariable = "This variable is not used anywhere";
+            string unusedVariable = "This variable is not used anywhere";
 
             return "Hello, World!";
         }
@@ -38,7 +38,7 @@
         public static string Concat(string str1, string str2)
         {
             // To test a second error, also comment out the line below so that a value is not returned
-            // return $"{str1} {str2}";
+            return $"{str1} {str2}";
         }
     }
 }

--- a/src/DotNet.CICDTest/DotNet.CICDTest.cs
+++ b/src/DotNet.CICDTest/DotNet.CICDTest.cs
@@ -1,0 +1,43 @@
+﻿namespace jmsudar.DotNet.CICDTest
+{
+    /// <summary>
+    /// This class contains methods that can be used for testing purposes.
+    /// </summary>
+    public static class TestMethods
+    {
+        /// <summary>
+        /// Returns a greeting message.
+        /// </summary>
+        /// <returns>A simple Hello, World statement</returns>
+        public static string GetGreeting()
+        {
+            // To test presentation of warnings, uncomment the line below to set an unused variable
+            // string unusedVariable = "This variable is not used anywhere";
+
+            return "Hello, World!";
+        }
+
+        /// <summary>
+        /// Adds two integers and returns the result.
+        /// </summary>
+        /// <param name="a">The first integer</param>
+        /// <param name="b">The second integer</param>
+        /// <returns>The sum of the two integers</returns>
+        public static int Add(int a, int b)
+        {
+            // To test presentation of errors, comment out the line below so that a value is not returned
+            return a + b;
+        }
+
+        /// <summary>
+        /// Concatenates two strings with a space in between.
+        /// </summary>
+        /// <param name="str1">The first string</param>
+        /// <param name="str2">The second string</param>
+        /// <returns>The concatenated string</returns>
+        public static string Concat(string str1, string str2)
+        {
+            return $"{str1} {str2}";
+        }
+    }
+}

--- a/src/DotNet.CICDTest/DotNet.CICDTest.cs
+++ b/src/DotNet.CICDTest/DotNet.CICDTest.cs
@@ -12,7 +12,7 @@
         public static string GetGreeting()
         {
             // To test presentation of warnings, uncomment the line below to set an unused variable
-            string unusedVariable = "This variable is not used anywhere";
+            // string unusedVariable = "This variable is not used anywhere";
 
             return "Hello, World!";
         }
@@ -37,7 +37,8 @@
         /// <returns>The concatenated string</returns>
         public static string Concat(string str1, string str2)
         {
-            return $"{str1} {str2}";
+            // To test a second error, also comment out the line below so that a value is not returned
+            // return $"{str1} {str2}";
         }
     }
 }

--- a/src/DotNet.CICDTest/DotNet.CICDTest.cs
+++ b/src/DotNet.CICDTest/DotNet.CICDTest.cs
@@ -12,7 +12,7 @@
         public static string GetGreeting()
         {
             // To test presentation of warnings, uncomment the line below to set an unused variable
-            string unusedVariable = "This variable is not used anywhere";
+            // string unusedVariable = "This variable is not used anywhere";
 
             return "Hello, World!";
         }

--- a/src/DotNet.CICDTest/DotNet.CICDTest.cs
+++ b/src/DotNet.CICDTest/DotNet.CICDTest.cs
@@ -12,7 +12,7 @@
         public static string GetGreeting()
         {
             // To test presentation of warnings, uncomment the line below to set an unused variable
-            // string unusedVariable = "This variable is not used anywhere";
+            string unusedVariable = "This variable is not used anywhere";
 
             return "Hello, World!";
         }

--- a/src/DotNet.CICDTest/DotNet.CICDTest.cs
+++ b/src/DotNet.CICDTest/DotNet.CICDTest.cs
@@ -26,7 +26,7 @@
         public static int Add(int a, int b)
         {
             // To test presentation of errors, comment out the line below so that a value is not returned
-            return a + b;
+            //return a + b;
         }
 
         /// <summary>

--- a/src/DotNet.CICDTest/DotNet.CICDTest.csproj
+++ b/src/DotNet.CICDTest/DotNet.CICDTest.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
# Overview

This is a comprehensive test of [jmsudar_dotnet-continuous-integration](https://github.com/jmsudar/dotnet-continuous-integration) and [jmsudar_dotnet-continuous-deployment](https://github.com/jmsudar/dotnet-continuous-deployment). As a component of testing the CD action it will also test [jmsudar.DotNet.UpdateCSProjFile](https://github.com/jmsudar/dotnet-update-csproj-file).

In order to test this successfully, several things need to be proven:
- CI should fast fail if there is no repository variable for the NuGet API key (assumed to be `NUGET_API_KEY`).
- CI should visually surface a successful build's details as well any warnings or errors. An error should fail CI and block a PR.
- CI should run all unit tests and surface any failed tests, the number of successful tests, and any skipped tests. Failing a unit test should block a PR.
- CD should successfully push the built library within this repo to NuGet.
- CD should successfully increment the version, create a changelog, and create a release assuming the NuGet pack and push is successful.

Because this is an integration test, each of these cases will be tested individually by manipulating elements of the run to cause failures or successes, and the details will be brought back here to update the `Testing` block of this PR description.

# Testing

## Fast-fail if no `NUGET_API_KEY` is set

As expected, the run failed.

<img width="1664" height="689" alt="Screenshot 2025-07-21 at 12 09 22 PM" src="https://github.com/user-attachments/assets/f08f0822-7f93-4271-bed6-936fc8ff8d7c" />

## Require CI to pass before merging.

To reach this state, set a simple branch protection rule (I used classic since at this point in time I am the sole contributor to my work)
- branch pattern: `main`
- Require a pull request before merging
- Require passing status checks `build-and-test`

As expected, the PR cannot be merged until the check passes.

<img width="936" height="257" alt="Screenshot 2025-07-22 at 6 35 31 AM" src="https://github.com/user-attachments/assets/74f87e84-5e5b-4fb0-b4d0-b56125c9b82a" />

## Fail if the project can't build

In this case, the test is to intentionally make the project build fail. To do this simply comment out line 29 so that the `Add` function doesn't return a value.

There's also no reason not to test warnings presentation at this stage

